### PR TITLE
BlogCategory-> LookForExistingURLSegment() fixes

### DIFF
--- a/code/model/BlogCategory.php
+++ b/code/model/BlogCategory.php
@@ -73,11 +73,9 @@ class BlogCategory extends DataObject {
     
     //Test whether the URLSegment exists already on another Product
     public function LookForExistingURLSegment($URLSegment){
-        if(DataList::create('BlogCategory')->where("URLSegment = '" . $URLSegment ."' AND ID != " . $this->ID)->count() >= 1){
-            return true;
-        } else {
-            return false;
-        }
+        $existing = BlogCategory::get()->filter("URLSegment",$URLSegment); 
+        if($this->ID) $existing = $existing->exclude("ID", $this->ID);
+        return $existing->count();
     }
     
     /**

--- a/code/model/BlogCategory.php
+++ b/code/model/BlogCategory.php
@@ -73,7 +73,10 @@ class BlogCategory extends DataObject {
     
     //Test whether the URLSegment exists already on another Product
     public function LookForExistingURLSegment($URLSegment){
-        $existing = BlogCategory::get()->filter("URLSegment",$URLSegment); 
+        $existing = BlogCategory::get()->filter(array(
+            "URLSegment" => $URLSegment,
+            'ParentID' => $this->ParentID
+        )); 
         if($this->ID) $existing = $existing->exclude("ID", $this->ID);
         return $existing->count();
     }


### PR DESCRIPTION
Limit duplicate detection to current blog holder, so multiple blog trees can share a subset of categories without requiring different sub-urls (so `blogs/my-blog/my-tag` and `blogs/my-other-blog/my-tag` both work).
