### PR TITLE
API Remove BlogCategory.Entry.AbstractImage, not defined in datamodel

### DIFF
--- a/code/BlogCategoryEntry.php
+++ b/code/BlogCategoryEntry.php
@@ -16,10 +16,7 @@ class BlogCategoryEntry extends DataExtension {
     public function updateCMSFields(FieldList $fields){
         
         Requirements::CSS('BlogCategories/css/cms-blog-categories.css');
-        
-        //main tab
-        $fields->addFieldToTab('Root.Main', new UploadField('AbstractImage', 'Abstract Image - 160x155px'));
-        
+                
         //creating a list of categories for the togglecompositefield
         if($this->owner->Parent->BlogCategories()->count() >= 1){
             $categoryList = "<ul>";


### PR DESCRIPTION
And it shouldn't be, since it has nothing to do with the categories feature of this module
