### PR TITLE
Cache BlogCategories <ul> to speed up large lists

### DIFF
--- a/code/BlogCategoryEntry.php
+++ b/code/BlogCategoryEntry.php
@@ -20,12 +20,17 @@ class BlogCategoryEntry extends DataExtension {
         // Try to fetch categories from cache                
         $categories = $this->getAllBlogCategories();
         if($categories->count() >= 1){
-            $categoryList = "<ul>";
-            foreach ($categories->column('Title') as $title) {
-                $categoryList .= "<li>" .Convert::raw2xml($title). "</li>";
+            $cacheKey = md5($categories->sort('LastEdited', 'DESC')->First()->LastEdited);
+            $cache = SS_Cache::factory('BlogCategoriesList');
+            if(!($categoryList = $cache->load($cacheKey))) {
+                $categoryList = "<ul>";
+                foreach ($categories->column('Title') as $title) {
+                    $categoryList .= "<li>" .Convert::raw2xml($title). "</li>";
+                }
+                $categoryList .="</ul>";
+                $cache->save($categoryList, $cacheKey);
             }
-            $categoryList .="</ul>";
-        }else {
+        } else {
             $categoryList="<ul><li>No categories have been added. Add categories from the parent blog holder.</li></ul>";            
         }
 


### PR DESCRIPTION
I've got a blog here that manages 2500 categories, in 3500 posts (I know, they go all-out with tagging...). Anyway, its quite CPU intensive to calc this list each time, so I'm caching it based on the LastEdited values of all categories.
