### PR TITLE
Fixed permission issue with BlogCategory class

### DIFF
--- a/code/model/BlogCategory.php
+++ b/code/model/BlogCategory.php
@@ -88,6 +88,16 @@ class BlogCategory extends DataObject {
     public function getLink(){
         return Controller::join_links(Director::get_current_page(), $this->Parent()->Link(), 'category', $this->URLSegment);
     }
+
+
+    public function canCreate($member = null) { return true; }
+
+    public function canView($member = null) { return true; }
+
+    public function canEdit($member = null) { return true; }
+
+    public function canDelete($member = null) { return true; }
+
           
 }
 ?>


### PR DESCRIPTION
Noticed that non-Administrator groups in the CMS were unable to administrate the blog categories. Adding the basic permission stuff to the model seems to fix it. However, might be good to look at possibly tying this into the main Blog module's security model. That being said, it looks like even the Blog module needs some security fixes. Turning off "Blog management" in Groups doesn't seem to do all that much.
